### PR TITLE
docs: document npm package rename and migration path (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to DSH Computer Use are recorded here. The project follows s
 
 ### Documentation
 
+- Documented the npm package name as `@anionex/dsh-computer-use`: the former `@dsh-external/dsh-computer-use` name was never published to npm, so downstream profiles must reference the current name.
 - Reworked the public repository facade around non-interfering target-process input, the fresh-observation protocol, deterministic native proof, permissions, security, support, and contribution paths.
 - Added a reusable native-integrity command and structured community intake.
 - Documented the Codex Computer Use alignment evidence (`SynthesizedEvent.send(to: pid)` and `CGWindow.window(at:)`) behind the screen-coordinate and keyboard-policy behavior.

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write dsh-computer-use/README.md
-README.md: 0447b8679a6278ad42fbcf05beb10b66bf32fea8
-README.zh.md: 87a5b1556abd96fdf8250401b27dd4ee8a3a127e
+README.md: 712c9674a45e3d6b041ffc5db8492a7a3a7474a9
+README.zh.md: 1e8b5d5f4dfce1aca26736077523bf19e4de9f2b

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ See [Foreground-safe input policy](docs/interaction-policy.md) for the requireme
 
 Install the Web and Headless bundles directly from npm:
 
+> [!IMPORTANT]
+> The published package name is `@anionex/dsh-computer-use`. The former
+> `@dsh-external/dsh-computer-use` name was never published to npm and is not
+> installable; update any old profile or manifest references before installing.
+
 ```sh
 dsh plugin --profile web add @anionex/dsh-computer-use
 dsh plugin --profile headless add @anionex/dsh-computer-use

--- a/README.zh.md
+++ b/README.zh.md
@@ -78,6 +78,11 @@ Fixture 会记录每次 `applicationDidBecomeActive` 回调。独立 native moni
 
 直接从 npm 一键安装 Web 与 Headless Bundle：
 
+> [!IMPORTANT]
+> 已发布的包名为 `@anionex/dsh-computer-use`。旧名
+> `@dsh-external/dsh-computer-use` 从未发布到 npm，不可安装；
+> 安装前请先更新旧的 profile 或 manifest 引用。
+
 ```sh
 dsh plugin --profile web add @anionex/dsh-computer-use
 dsh plugin --profile headless add @anionex/dsh-computer-use


### PR DESCRIPTION
Closes #7

The package is published as `@anionex/dsh-computer-use`; the former `@dsh-external/dsh-computer-use` name was never published to npm (registry 404) and is not installable. This documents that fact and the migration path in README (en/zh), the changelog, and the i18n consistency record.